### PR TITLE
clean up metatable pushing

### DIFF
--- a/func.go
+++ b/func.go
@@ -36,8 +36,7 @@ func checkFunc(l *lua.State, index int) reflect.Value {
 	return ref
 }
 
-func setupFunc(l *lua.State) {
-	defer l.Pop(1)
+func pushAndSetupFuncTable(l *lua.State) {
 	if !lua.NewMetaTable(l, funcName) {
 		return
 	}

--- a/interface.go
+++ b/interface.go
@@ -31,8 +31,7 @@ func checkInterface(l *lua.State, index int) reflect.Value {
 	return ref
 }
 
-func setupInterface(l *lua.State) {
-	defer l.Pop(1)
+func pushAndSetupInterfaceTable(l *lua.State) {
 	if !lua.NewMetaTable(l, interfaceName) {
 		return
 	}

--- a/luar.go
+++ b/luar.go
@@ -57,9 +57,9 @@ func PushReflectedValue(l *lua.State, val reflect.Value) (err error) {
 		return nil
 
 	case reflect.Struct:
-		setupStruct(l)
 		l.PushUserData(val)
-		lua.SetMetaTableNamed(l, structName)
+		pushAndSetupStructTable(l)
+		l.SetMetaTable(-2)
 
 		return nil
 
@@ -69,9 +69,9 @@ func PushReflectedValue(l *lua.State, val reflect.Value) (err error) {
 			return nil
 		}
 
-		setupPtr(l)
 		l.PushUserData(val)
-		lua.SetMetaTableNamed(l, ptrName)
+		pushAndSetupPtrTable(l)
+		l.SetMetaTable(-2)
 
 		return nil
 
@@ -81,9 +81,9 @@ func PushReflectedValue(l *lua.State, val reflect.Value) (err error) {
 			return nil
 		}
 
-		setupFunc(l)
 		l.PushUserData(val)
-		lua.SetMetaTableNamed(l, funcName)
+		pushAndSetupFuncTable(l)
+		l.SetMetaTable(-2)
 
 		return nil
 
@@ -93,9 +93,9 @@ func PushReflectedValue(l *lua.State, val reflect.Value) (err error) {
 			return nil
 		}
 
-		setupInterface(l)
 		l.PushUserData(val)
-		lua.SetMetaTableNamed(l, interfaceName)
+		pushAndSetupInterfaceTable(l)
+		l.SetMetaTable(-2)
 
 		return nil
 

--- a/ptr.go
+++ b/ptr.go
@@ -31,8 +31,7 @@ func checkPtr(l *lua.State, index int) reflect.Value {
 	return ref
 }
 
-func setupPtr(l *lua.State) {
-	defer l.Pop(1)
+func pushAndSetupPtrTable(l *lua.State) {
 	if !lua.NewMetaTable(l, ptrName) {
 		return
 	}

--- a/struct.go
+++ b/struct.go
@@ -79,8 +79,7 @@ func setField(l *lua.State, ref reflect.Value, name_idx int, val_idx int) int {
 	return 0
 }
 
-func setupStruct(l *lua.State) {
-	defer l.Pop(1)
+func pushAndSetupStructTable(l *lua.State) {
 	if !lua.NewMetaTable(l, structName) {
 		return
 	}


### PR DESCRIPTION
we used to:
	- push a metatable
	- initialize it if necessary
	- pop the metatable
	- push user data
	- push the same metatable
	- pop the metatable and set it on user data

instead:
	- push the user data
	- push the metatable
	- initialize it if necessary
	- pop the metatable and set it on user data